### PR TITLE
1.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 APP_ID := live_transcription
 APP_NAME := Live Transcription
-APP_VERSION := 1.0.1
+APP_VERSION := 1.1.0
 JSON_INFO := "{\"id\":\"$(APP_ID)\",\"name\":\"$(APP_NAME)\",\"daemon_config_name\":\"manual_install\",\"version\":\"$(APP_VERSION)\",\"secret\":\"12345\",\"port\":23000}"
 
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<description>
 	<![CDATA[Provides live transcriptions in Nextcloud Talk calls. High-performance backend (HPB) is required for this app to work.]]>
 	</description>
-	<version>1.0.1</version>
+	<version>1.1.0</version>
 	<licence>agpl</licence>
 	<author mail="kyteinsky@gmail.com" homepage="https://github.com/kyteinsky">Anupam Kumar</author>
 	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
@@ -27,7 +27,7 @@
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>nextcloud-releases/live_transcription</image>
-			<image-tag>1.0.1</image-tag>
+			<image-tag>1.1.0</image-tag>
 		</docker-install>
 		<environment-variables>
 			<variable>

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 
+## 1.1.0 - 2025-08-28
+
+### Added
+- Add reuse status badge (#6) @AndyScherzinger
+- add RTL support in language metadata (#7) @kyteinsky
+- add Arabic and Arabic Tunisian languages (#8) @kyteinsky
+- add langId in sent transcript signaling messages (#9) @kyteinsky
+- add app version to file logs (#13) @kyteinsky
+
+### Fixed
+- streamline error response in set-language call (#7) @kyteinsky
+- use ISO 639 language codes (#7) @kyteinsky
+- better error handling (#7) @kyteinsky
+- increase timeout for the model in vosk to load (#7) @kyteinsky
+- streamline error response in set-language call (#7) @kyteinsky
+- use the given language, not the global one in language switch (#14) @kyteinsky
+- use a stash list for unseen targets to be added (#13) @kyteinsky
+- load dotenv in the logger (#17) @kyteinsky
+
+### Changed
+- switch to Nextcloud session id for endpoints (#10) @kyteinsky
+- further clarify the env vars purpose in info.xml (#16) @kyteinsky
+- refactor out different classes and general utils into separate files (#17) @kyteinsky
+
+
 ## 1.0.1 - 2025-08-07
 
 ### Fixed


### PR DESCRIPTION
## 1.1.0 - 2025-08-28

### Added
- Add reuse status badge (#6) @AndyScherzinger
- add RTL support in language metadata (#7) @kyteinsky
- add Arabic and Arabic Tunisian languages (#8) @kyteinsky
- add langId in sent transcript signaling messages (#9) @kyteinsky
- add app version to file logs (#13) @kyteinsky

### Fixed
- streamline error response in set-language call (#7) @kyteinsky
- use ISO 639 language codes (#7) @kyteinsky
- better error handling (#7) @kyteinsky
- increase timeout for the model in vosk to load (#7) @kyteinsky
- streamline error response in set-language call (#7) @kyteinsky
- use the given language, not the global one in language switch (#14) @kyteinsky
- use a stash list for unseen targets to be added (#13) @kyteinsky
- load dotenv in the logger (#17) @kyteinsky

### Changed
- switch to Nextcloud session id for endpoints (#10) @kyteinsky
- further clarify the env vars purpose in info.xml (#16) @kyteinsky
- refactor out different classes and general utils into separate files (#17) @kyteinsky
