### PR TITLE
1.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 APP_ID := live_transcription
 APP_NAME := Live Transcription
-APP_VERSION := 1.1.0
+APP_VERSION := 1.1.1
 JSON_INFO := "{\"id\":\"$(APP_ID)\",\"name\":\"$(APP_NAME)\",\"daemon_config_name\":\"manual_install\",\"version\":\"$(APP_VERSION)\",\"secret\":\"12345\",\"port\":23000}"
 
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<description>
 	<![CDATA[Provides live transcriptions in Nextcloud Talk calls. High-performance backend (HPB) is required for this app to work.]]>
 	</description>
-	<version>1.1.0</version>
+	<version>1.1.1</version>
 	<licence>agpl</licence>
 	<author mail="kyteinsky@gmail.com" homepage="https://github.com/kyteinsky">Anupam Kumar</author>
 	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
@@ -27,7 +27,7 @@
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>nextcloud-releases/live_transcription</image>
-			<image-tag>1.1.0</image-tag>
+			<image-tag>1.1.1</image-tag>
 		</docker-install>
 		<environment-variables>
 			<variable>

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 
+## 1.1.1 - 2025-08-28
+
+### Fixed
+- pin nc_py_api to 0.20.2 (#19) @kyteinsky
+
+
 ## 1.1.0 - 2025-08-28
 
 ### Added


### PR DESCRIPTION
## 1.1.1 - 2025-08-28

### Fixed
- pin nc_py_api to 0.20.2 (#19) @kyteinsky
