### PR TITLE
1.1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 APP_ID := live_transcription
 APP_NAME := Live Transcription
-APP_VERSION := 1.1.1
+APP_VERSION := 1.1.2
 JSON_INFO := "{\"id\":\"$(APP_ID)\",\"name\":\"$(APP_NAME)\",\"daemon_config_name\":\"manual_install\",\"version\":\"$(APP_VERSION)\",\"secret\":\"12345\",\"port\":23000}"
 
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<description>
 	<![CDATA[Provides live transcriptions in Nextcloud Talk calls. High-performance backend (HPB) is required for this app to work.]]>
 	</description>
-	<version>1.1.1</version>
+	<version>1.1.2</version>
 	<licence>agpl</licence>
 	<author mail="kyteinsky@gmail.com" homepage="https://github.com/kyteinsky">Anupam Kumar</author>
 	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
@@ -27,7 +27,7 @@
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>nextcloud-releases/live_transcription</image>
-			<image-tag>1.1.1</image-tag>
+			<image-tag>1.1.2</image-tag>
 		</docker-install>
 		<environment-variables>
 			<variable>

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 
+## 1.1.2 - 2025-08-28
+
+### Fixed
+- use LT_DISABLE_INTERNAL_VOSK in vosk server (#21) @kyteinsky
+- override nc_py_api's NPA_NC_CERT based on SKIP_CERT_VERIFY (#23) @kyteinsky
+
+
 ## 1.1.1 - 2025-08-28
 
 ### Fixed


### PR DESCRIPTION
## 1.1.2 - 2025-08-28

### Fixed
- use LT_DISABLE_INTERNAL_VOSK in vosk server (#21) @kyteinsky
- override nc_py_api's NPA_NC_CERT based on SKIP_CERT_VERIFY (#23) @kyteinsky
