### PR TITLE
1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 APP_ID := live_transcription
 APP_NAME := Live Transcription
-APP_VERSION := 1.1.2
+APP_VERSION := 1.2.0
 JSON_INFO := "{\"id\":\"$(APP_ID)\",\"name\":\"$(APP_NAME)\",\"daemon_config_name\":\"manual_install\",\"version\":\"$(APP_VERSION)\",\"secret\":\"12345\",\"port\":23000}"
 
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<description>
 	<![CDATA[Provides live transcriptions in Nextcloud Talk calls. High-performance backend (HPB) is required for this app to work.]]>
 	</description>
-	<version>1.1.2</version>
+	<version>1.2.0</version>
 	<licence>agpl</licence>
 	<author mail="kyteinsky@gmail.com" homepage="https://github.com/kyteinsky">Anupam Kumar</author>
 	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
@@ -27,7 +27,7 @@
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>nextcloud-releases/live_transcription</image>
-			<image-tag>1.1.2</image-tag>
+			<image-tag>1.2.0</image-tag>
 		</docker-install>
 		<environment-variables>
 			<variable>

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 
+## 1.2.0 - 2025-09-11
+
+### Added
+- support sending partial transcript chunks (#22) @kyteinsky
+
+### Fixed
+- better HPB error message handling (#26) @kyteinsky
+- slow down transcript sent to 300ms (#26) @kyteinsky
+- better shutdown process (#26) @kyteinsky
+- drop the "the", it's cleaner (#26) @kyteinsky
+
+
 ## 1.1.2 - 2025-08-28
 
 ### Fixed


### PR DESCRIPTION
## 1.2.0 - 2025-09-11

### Added
- support sending partial transcript chunks (#22) @kyteinsky

### Fixed
- better HPB error message handling (#26) @kyteinsky
- slow down transcript sent to 300ms (#26) @kyteinsky
- better shutdown process (#26) @kyteinsky
- drop the "the", it's cleaner (#26) @kyteinsky
