### PR TITLE
1.2.1

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<description>
 	<![CDATA[Provides live transcriptions in Nextcloud Talk calls. High-performance backend (HPB) is required for this app to work.]]>
 	</description>
-	<version>1.2.0</version>
+	<version>1.2.1</version>
 	<licence>agpl</licence>
 	<author mail="kyteinsky@gmail.com" homepage="https://github.com/kyteinsky">Anupam Kumar</author>
 	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
@@ -21,13 +21,13 @@
 	<bugs>https://github.com/nextcloud/live_transcription/issues</bugs>
 	<repository type="git">https://github.com/nextcloud/live_transcription</repository>
 	<dependencies>
-		<nextcloud min-version="32" max-version="32"/>
+		<nextcloud min-version="32" max-version="33"/>
 	</dependencies>
 	<external-app>
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>nextcloud-releases/live_transcription</image>
-			<image-tag>1.2.0</image-tag>
+			<image-tag>1.2.1</image-tag>
 		</docker-install>
 		<environment-variables>
 			<variable>

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 
+## 1.2.1 - 2025-11-05
+
+### Fixed
+- return gracefully on vosk connection error (#29) @kyteinsky
+
+### Changed
+- bump max NC version to 33
+
+
 ## 1.2.0 - 2025-09-11
 
 ### Added


### PR DESCRIPTION
## 1.2.1 - 2025-11-05

### Fixed
- return gracefully on vosk connection error (#29) @kyteinsky

### Changed
- bump max NC version to 33
