### PR TITLE
1.2.3

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@ The installation steps can be found here: https://docs.nextcloud.com/server/late
 IMPORTANT: Environment variables "LT_HPB_URL" and "LT_INTERNAL_SECRET" are required to be set in "Deploy Options" near the "Deploy and Enable" button before the install.
 ]]>
 	</description>
-	<version>1.2.2</version>
+	<version>1.2.3</version>
 	<licence>agpl</licence>
 	<author mail="kyteinsky@gmail.com" homepage="https://github.com/kyteinsky">Anupam Kumar</author>
 	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
@@ -32,7 +32,7 @@ IMPORTANT: Environment variables "LT_HPB_URL" and "LT_INTERNAL_SECRET" are requi
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>nextcloud-releases/live_transcription</image>
-			<image-tag>1.2.2</image-tag>
+			<image-tag>1.2.3</image-tag>
 		</docker-install>
 		<environment-variables>
 			<variable>

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 
+## 1.2.3 - 2025-11-25
+
+### Fixed
+- pure asyncio locks (#44) @kyteinsky
+- prevent race condition of start when a client is shutting down (#44) @kyteinsky
+- increase HPB timeout and add reconnection logic (#44) @kyteinsky
+- use HPB session id to remove targets from signaling messages (#44) @kyteinsky
+- ensure peer connections are healthy on reconnect (#44) @kyteinsky
+- pause sending transcript until the HPB connection re-establishes (#44) @kyteinsky
+
+
 ## 1.2.2 - 2025-11-07
 
 ### Fixed


### PR DESCRIPTION
## 1.2.3 - 2025-11-25

### Fixed
- pure asyncio locks (#44) @kyteinsky
- prevent race condition of start when a client is shutting down (#44) @kyteinsky
- increase HPB timeout and add reconnection logic (#44) @kyteinsky
- use HPB session id to remove targets from signaling messages (#44) @kyteinsky
- ensure peer connections are healthy on reconnect (#44) @kyteinsky
- pause sending transcript until the HPB connection re-establishes (#44) @kyteinsky
