### PR TITLE
fix: ignore client_not_found errors

### DIFF
--- a/ex_app/lib/spreed_client.py
+++ b/ex_app/lib/spreed_client.py
@@ -880,6 +880,10 @@ class SpreedClient:
 					# this is most probably related to a transcript reception failure on HPB side
 					# we can try to continue
 					continue
+				if message.get("error", {}).get("code") == "client_not_found":
+					# "No MCU client found to send message to."
+					# transcript sent to a participant who is not in the call anymore
+					continue
 
 				# only close if the error is not recoverable
 				if not self._close_task:


### PR DESCRIPTION
"No MCU client found to send message to."
transcript sent to a participant who is not in the call anymore