### PR TITLE
2.1.1

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@ The installation steps can be found here: https://docs.nextcloud.com/server/late
 IMPORTANT: Environment variables "LT_HPB_URL" and "LT_INTERNAL_SECRET" are required to be set in "Deploy Options" near the "Deploy and Enable" button before the install.
 ]]>
 	</description>
-	<version>2.1.0</version>
+	<version>2.1.1</version>
 	<licence>agpl</licence>
 	<author mail="kyteinsky@gmail.com" homepage="https://github.com/kyteinsky">Anupam Kumar</author>
 	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
@@ -32,7 +32,7 @@ IMPORTANT: Environment variables "LT_HPB_URL" and "LT_INTERNAL_SECRET" are requi
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>nextcloud-releases/live_transcription</image>
-			<image-tag>2.1.0</image-tag>
+			<image-tag>2.1.1</image-tag>
 		</docker-install>
 		<environment-variables>
 			<variable>

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1.1 - 2026-04-17
+
+### Fixed
+- get HPB settings in a lazy way to not crash on startup ([#75](https://github.com/nextcloud/live_transcription/pull/75)) @kyteinsky
+
+
 ## 2.1.0 - 2026-03-03
 
 ### Added

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -19,6 +19,15 @@ release_agent:
   - author: "^dependabot\\[bot\\]$"
   - message: "^chore\\(changelog\\):"
 entries:
+- version: 2.1.1
+  release_date: '2026-04-17'
+  sections:
+  - name: Fixed
+    items:
+    - text: get HPB settings in a lazy way to not crash on startup
+      authors:
+      - kyteinsky
+      issue_number: 75
 - version: 2.1.0
   release_date: '2026-03-03'
   sections:


### PR DESCRIPTION
## 2.1.1 - 2026-04-17

### Fixed
- get HPB settings in a lazy way to not crash on startup ([#75](https://github.com/nextcloud/live_transcription/pull/75)) @kyteinsky