### PR TITLE
1.3.1

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@ The installation steps can be found here: https://docs.nextcloud.com/server/late
 IMPORTANT: Environment variables "LT_HPB_URL" and "LT_INTERNAL_SECRET" are required to be set in "Deploy Options" near the "Deploy and Enable" button before the install.
 ]]>
 	</description>
-	<version>1.3.0</version>
+	<version>1.3.1</version>
 	<licence>agpl</licence>
 	<author mail="kyteinsky@gmail.com" homepage="https://github.com/kyteinsky">Anupam Kumar</author>
 	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
@@ -32,7 +32,7 @@ IMPORTANT: Environment variables "LT_HPB_URL" and "LT_INTERNAL_SECRET" are requi
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>nextcloud-releases/live_transcription</image>
-			<image-tag>1.3.0</image-tag>
+			<image-tag>1.3.1</image-tag>
 		</docker-install>
 		<environment-variables>
 			<variable>

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 
+## 1.3.1 - 2026-04-17
+
+### Changed
+- set max NC version to 32
+- add a transcript queue length log when the size exceeds 20 (#68) @kyteinsky
+
+### Fixed
+- ignore client_not_found errors (#69) @kyteinsky
+- get HPB settings in a lazy way to not crash on startup (#76) @kyteinsky
+
+
 ## 1.3.0 - 2025-12-02
 
 ### Added


### PR DESCRIPTION
## 1.3.1 - 2026-04-17

### Changed
- set max NC version to 32
- add a transcript queue length log when the size exceeds 20 (#68) @kyteinsky

### Fixed
- ignore client_not_found errors (#69) @kyteinsky
- get HPB settings in a lazy way to not crash on startup (#76) @kyteinsky
