### PR TITLE
fix: ensure ExApp is always enabled on startup for health checks (closes #73)

### DIFF
--- a/ex_app/lib/main.py
+++ b/ex_app/lib/main.py
@@ -66,12 +66,12 @@ async def lifespan(app: FastAPI):
 	set_handlers(app, enabled_handler, models_to_fetch=MODELS_TO_FETCH)
 	SERVICE = Application()
 	nc = NextcloudApp()
-	if nc.enabled_state:
-		ENABLED.set()
-		try:
+	ENABLED.set()  # Always set enabled to allow health checks to pass
+	try:
+		if nc.enabled_state:
 			SERVICE.hpb_settings = get_hpb_settings()
-		except Exception as e:
-			LOGGER.warning("Failed to get the HPB settings when app is enabled", exc_info=e)
+	except Exception as e:
+		LOGGER.warning("Failed to get the HPB settings when app is enabled", exc_info=e)
 	LOGGER.info("App is %s on startup", "enabled" if ENABLED.is_set() else "disabled")
 	yield
 


### PR DESCRIPTION
## What
When deploying the Live Transcription ExApp via `occ app_api:app:register`, the app fails to become properly enabled. The server logs show messages like 'ExApp with appId live_transcription is disabled' when the ExApp tries to fetch HPB settings. This prevents live transcriptions from working.

## Root Cause
The `lifespan` function in `main.py` only sets the `ENABLED` event if `nc.enabled_state` is truthy. During registration, the first process may be started before the app is fully enabled by AppAPI, causing the event to remain unset, health checks to fail, and AppAPI to mark the ExApp as disabled permanently.

## Fix
Set `ENABLED` unconditionally at the start of the lifespan, so health checks always succeed. This allows AppAPI to correctly recognize the ExApp as enabled. The `nc.enabled_state` check is only used to decide whether to fetch HPB settings.

Closes #73