### PR TITLE
2.1.3

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@ The installation steps can be found here: https://docs.nextcloud.com/server/late
 IMPORTANT: Environment variables "LT_HPB_URL" and "LT_INTERNAL_SECRET" are required to be set in "Deploy Options" near the "Deploy and Enable" button before the install.
 ]]>
 	</description>
-	<version>2.1.2</version>
+	<version>2.1.3</version>
 	<licence>agpl</licence>
 	<author mail="kyteinsky@gmail.com" homepage="https://github.com/kyteinsky">Anupam Kumar</author>
 	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
@@ -32,7 +32,7 @@ IMPORTANT: Environment variables "LT_HPB_URL" and "LT_INTERNAL_SECRET" are requi
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>nextcloud-releases/live_transcription</image>
-			<image-tag>2.1.2</image-tag>
+			<image-tag>2.1.3</image-tag>
 		</docker-install>
 		<environment-variables>
 			<variable>

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1.3 - 2026-08-19
+
+### Changed
+- add NC 35 support ([#86](https://github.com/nextcloud/live_transcription/pull/86)) @kyteinsky
+- minor fixes ([#90](https://github.com/nextcloud/live_transcription/pull/90)) @kyteinsky
+
+### Fixed
+- remove redundant lines ([#87](https://github.com/nextcloud/live_transcription/pull/87)) @kyteinsky
+
+
 ## 2.1.2 - 2026-05-07
 
 ### Changed

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -19,6 +19,25 @@ release_agent:
   - author: "^dependabot\\[bot\\]$"
   - message: "^chore\\(changelog\\):"
 entries:
+- version: 2.1.3
+  release_date: '2026-08-19'
+  sections:
+  - name: Changed
+    items:
+    - text: add NC 35 support
+      authors:
+      - kyteinsky
+      issue_number: 86
+    - text: minor fixes
+      authors:
+      - kyteinsky
+      issue_number: 90
+  - name: Fixed
+    items:
+    - text: remove redundant lines
+      authors:
+      - kyteinsky
+      issue_number: 87
 - version: 2.1.2
   release_date: '2026-05-07'
   sections:


### PR DESCRIPTION
## 2.1.3 - 2026-08-19

### Changed
- add NC 35 support ([#86](https://github.com/nextcloud/live_transcription/pull/86)) @kyteinsky
- minor fixes ([#90](https://github.com/nextcloud/live_transcription/pull/90)) @kyteinsky

### Fixed
- remove redundant lines ([#87](https://github.com/nextcloud/live_transcription/pull/87)) @kyteinsky